### PR TITLE
Allow workflow for helm chart auto release 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build kafka-operator
         uses: docker/build-push-action@v3
         with:
-          tags: ghcr.io/banzaicloud/kafka-operator:${{ steps.imagetag.outputs.value }}
+          tags: ghcr.io/klarrio-oss/kafka-operator:${{ steps.imagetag.outputs.value }}
           file: Dockerfile
           platforms: ${{ env.PLATFORMS }}
           push: true

--- a/.github/workflows/docker_perf_test_load.yml
+++ b/.github/workflows/docker_perf_test_load.yml
@@ -44,7 +44,7 @@ jobs:
         id: setup-docker-metadata
         uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/banzaicloud/koperator-performance-test-load
+          images: ghcr.io/klarrio-oss/koperator-performance-test-load
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -56,7 +56,7 @@ jobs:
       - name: Build koperator-performance-test-load
         uses: docker/build-push-action@v3
         with:
-          tags: ghcr.io/banzaicloud/koperator-performance-test-load:${{ steps.imagetag.outputs.value }}
+          tags: ghcr.io/klarrio-oss/koperator-performance-test-load:${{ steps.imagetag.outputs.value }}
           file: docs/benchmarks/loadgens/Dockerfile
           platforms: ${{ env.PLATFORMS }}
           push: true

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,0 +1,26 @@
+name: Release Charts
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+    - name: Run chart-releaser
+      uses: helm/chart-releaser-action@v1.6.0
+      env:
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - master
     tags:
-    - 'v?[0-9]+.[0-9]+.[0-9]+'
+    - 'chart/**/[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
     - master
+    tags:
+    - 'v?[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Concatenate CRDs
         run: |
@@ -39,7 +39,7 @@ jobs:
             ## Upgrade Notes:
             - TODO
 
-            [v#TODO...${{ github.ref }}](https://github.com/banzaicloud/koperator/compare/v#TODO...${{ github.ref }})
+            [v#TODO...${{ github.ref }}](https://github.com/klarrio-oss/koperator/compare/v#TODO...${{ github.ref }})
 
             Thanks for the huge help from the community 🍺
           prerelease: false

--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.26.1
+version: 0.26.2
 description: Helm chart for kafka-operator to manage Kafka deployments on Kubernetes
 sources:
   - https://github.com/klarrio-oss/koperator
-appVersion: v0.26.1
+appVersion: v0.26.2

--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
 version: 0.26.1
-description: kafka-operator manages Kafka deployments on Kubernetes
+description: Helm chart for kafka-operator to manage Kafka deployments on Kubernetes
 sources:
   - https://github.com/klarrio-oss/koperator
 appVersion: v0.26.1

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -11,7 +11,7 @@ replicaCount: 1
 operator:
   annotations: {}
   image:
-    repository: ghcr.io/banzaicloud/kafka-operator
+    repository: ghcr.io/klarrio-oss/kafka-operator
     tag: ""
     pullPolicy: IfNotPresent
   # In constrained environments where operator cannot


### PR DESCRIPTION
## Description

Adds support for automatic helm chart release using Helm Chart Releaser Action. The previous `helm.yaml` workflow is still there as it will only require some changes to work that were out of the scope but the check it does and the process is still relevant.

Chart version is also increased.

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] New Feature
