### PR TITLE
Remove push to master chart-release workflow trigger

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,8 +1,6 @@
 name: Release Charts
 on:
   push:
-    branches:
-    - master
     tags:
     - 'chart/**/[0-9]+.[0-9]+.[0-9]+'
 


### PR DESCRIPTION
## Description

I thought selecting as trigger a push to a specific branch + push tag would require both conditions to be met, but that is not implemented yet as seen in https://github.com/orgs/community/discussions/13226 So removing the `master` branch push trigger to avoid releasing on every PR merged.

## Type of Change
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [X] New Feature
